### PR TITLE
Add bump-my-version

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,0 +1,25 @@
+[tool.bumpversion]
+current_version = "0.0.0.9000"
+search = "{current_version}"
+replace = "{new_version}"
+message = "Bump version: {current_version} → {new_version}"
+regex = false
+ignore_missing_version = false
+ignore_missing_files = false
+commit = true
+parse = """(?x)
+    (?P<major>0|[1-9]\\d*)\\.
+    (?P<minor>0|[1-9]\\d*)\\.
+    (?P<patch>0|[1-9]\\d*)
+    (?:\\.(?P<dev>\\d+))?
+"""
+
+serialize = [
+    "{major}.{minor}.{patch}.{dev}",
+    "{major}.{minor}.{patch}",
+]
+
+[[tool.bumpversion.files]]
+filename = "DESCRIPTION"
+search = "Version: {current_version}"
+replace = "Version: {new_version}"


### PR DESCRIPTION
Adding support for <https://github.com/callowayproject/bump-my-version>.
Starting just with the DESCRIPTION for now, later on might add conda recipe.
Example use:

```
$ bump-my-version show-bump
0.0.0.9000 ── bump ─┬─ major ─ 1.0.0
                    ├─ minor ─ 0.1.0
                    ├─ patch ─ 0.0.1
                    ╰─ dev ─── 0.0.0.9001               
$ bump-my-version bump dev --dry-run -v
[...]
[lots of verbose output showing which files will change and how]

$ bump-my-version bump --new-version 0.0.1
$ bump-my-version bump dev # or patch, minor, major
```