### PR TITLE
nemofy: use renamed args

### DIFF
--- a/R/Alignments.R
+++ b/R/Alignments.R
@@ -8,7 +8,7 @@
 #' odir <- tempdir()
 #' id <- "alignments_run1"
 #' obj <- cls$new(indir)
-#' obj$nemofy(odir = odir, format = "parquet", input_id = id)
+#' obj$nemofy(diro = odir, format = "parquet", input_id = id)
 #' (lf <- list.files(odir, pattern = "alignments.*parquet", full.names = FALSE))
 #' @testexamples
 #' expect_equal(grepv("parquet", lf), "sample1_alignments_dupfreq.parquet")

--- a/R/Amber.R
+++ b/R/Amber.R
@@ -8,7 +8,7 @@
 #' odir <- tempdir()
 #' id <- "amber_run1"
 #' obj <- cls$new(indir)
-#' obj$nemofy(odir = odir, format = "parquet", input_id = id)
+#' obj$nemofy(diro = odir, format = "parquet", input_id = id)
 #' (lf <- list.files(odir, pattern = "amber.*parquet", full.names = FALSE))
 #' @testexamples
 #' expect_equal(length(lf), 4)

--- a/R/Bamtools.R
+++ b/R/Bamtools.R
@@ -8,7 +8,7 @@
 #' odir <- tempdir()
 #' id <- "bamtools_run1"
 #' obj <- cls$new(indir)
-#' obj$nemofy(odir = odir, format = "parquet", input_id = id)
+#' obj$nemofy(diro = odir, format = "parquet", input_id = id)
 #' (lf <- list.files(odir, pattern = "bamtools.*parquet", full.names = FALSE))
 #' @testexamples
 #' expect_equal(length(lf), 11)

--- a/R/Chord.R
+++ b/R/Chord.R
@@ -8,7 +8,7 @@
 #' odir <- tempdir()
 #' id <- "chord_run1"
 #' obj <- cls$new(indir)
-#' obj$nemofy(odir = odir, format = "parquet", input_id = id)
+#' obj$nemofy(diro = odir, format = "parquet", input_id = id)
 #' (lf <- list.files(odir, pattern = "chord.*parquet", full.names = FALSE))
 #' @testexamples
 #' expect_equal(length(lf), 2)

--- a/R/Cider.R
+++ b/R/Cider.R
@@ -8,7 +8,7 @@
 #' odir <- tempdir()
 #' id <- "cider_run1"
 #' obj <- cls$new(indir)
-#' obj$nemofy(odir = odir, format = "parquet", input_id = id)
+#' obj$nemofy(diro = odir, format = "parquet", input_id = id)
 #' (lf <- list.files(odir, pattern = "cider.*parquet", full.names = FALSE))
 #' @testexamples
 #' expect_equal(length(lf), 3)

--- a/R/Cobalt.R
+++ b/R/Cobalt.R
@@ -8,7 +8,7 @@
 #' odir <- tempdir()
 #' id <- "cobalt_run1"
 #' obj <- cls$new(indir)
-#' obj$nemofy(odir = odir, format = "parquet", input_id = id)
+#' obj$nemofy(diro = odir, format = "parquet", input_id = id)
 #' (lf <- list.files(odir, pattern = "cobalt.*parquet", full.names = FALSE))
 #' @testexamples
 #' expect_equal(length(lf), 5)

--- a/R/Cuppa.R
+++ b/R/Cuppa.R
@@ -8,7 +8,7 @@
 #' odir <- tempdir()
 #' id <- "cuppa_run1"
 #' obj <- cls$new(indir)
-#' obj$nemofy(odir = odir, format = "parquet", input_id = id)
+#' obj$nemofy(diro = odir, format = "parquet", input_id = id)
 #' (lf <- list.files(odir, pattern = "cuppa.*parquet", full.names = FALSE))
 #' @testexamples
 #' expect_equal(length(lf), 3)

--- a/R/Esvee.R
+++ b/R/Esvee.R
@@ -8,7 +8,7 @@
 #' odir <- tempdir()
 #' id <- "esvee_run1"
 #' obj <- cls$new(indir)
-#' obj$nemofy(odir = odir, format = "parquet", input_id = id)
+#' obj$nemofy(diro = odir, format = "parquet", input_id = id)
 #' (lf <- list.files(odir, pattern = "cobalt.*parquet", full.names = FALSE))
 #' #TODO: add esvee test data
 #' @export

--- a/R/Flagstats.R
+++ b/R/Flagstats.R
@@ -8,7 +8,7 @@
 #' odir <- tempdir()
 #' id <- "flagstats_run1"
 #' obj <- cls$new(indir)
-#' obj$nemofy(odir = odir, format = "parquet", input_id = id)
+#' obj$nemofy(diro = odir, format = "parquet", input_id = id)
 #' (lf <- list.files(odir, pattern = "parquet", full.names = FALSE))
 #' #TODO: add flagstats test data
 #' @export

--- a/R/Isofox.R
+++ b/R/Isofox.R
@@ -8,7 +8,7 @@
 #' odir <- tempdir()
 #' id <- "isofox_run1"
 #' obj <- cls$new(indir)
-#' obj$nemofy(odir = odir, format = "parquet", input_id = id)
+#' obj$nemofy(diro = odir, format = "parquet", input_id = id)
 #' (lf <- list.files(odir, pattern = "parquet", full.names = FALSE))
 #' #TODO: add isofox test data
 #' @export

--- a/R/Lilac.R
+++ b/R/Lilac.R
@@ -8,7 +8,7 @@
 #' odir <- tempdir()
 #' id <- "lilac_run1"
 #' obj <- cls$new(indir)
-#' obj$nemofy(odir = odir, format = "parquet", input_id = id)
+#' obj$nemofy(diro = odir, format = "parquet", input_id = id)
 #' (lf <- list.files(odir, pattern = "lilac.*parquet", full.names = FALSE))
 #' @testexamples
 #' expect_equal(length(lf), 2)

--- a/R/Linx.R
+++ b/R/Linx.R
@@ -8,7 +8,7 @@
 #' odir <- tempdir()
 #' id <- "linx_run1"
 #' obj <- cls$new(indir)
-#' obj$nemofy(odir = odir, format = "parquet", input_id = id)
+#' obj$nemofy(diro = odir, format = "parquet", input_id = id)
 #' (lf <- list.files(odir, pattern = "linx.*parquet", full.names = FALSE))
 #' @testexamples
 #' expect_equal(length(lf), 20)

--- a/R/Neo.R
+++ b/R/Neo.R
@@ -8,7 +8,7 @@
 #' odir <- tempdir()
 #' id <- "neo_run1"
 #' obj <- cls$new(indir)
-#' obj$nemofy(odir = odir, format = "parquet", input_id = id)
+#' obj$nemofy(diro = odir, format = "parquet", input_id = id)
 #' (lf <- list.files(odir, pattern = "neo.*parquet", full.names = FALSE))
 #' @testexamples
 #' expect_equal(length(lf), 2)

--- a/R/Peach.R
+++ b/R/Peach.R
@@ -8,7 +8,7 @@
 #' odir <- tempdir()
 #' id <- "peach_run1"
 #' obj <- cls$new(indir)
-#' obj$nemofy(odir = odir, format = "parquet", input_id = id)
+#' obj$nemofy(diro = odir, format = "parquet", input_id = id)
 #' (lf <- list.files(odir, pattern = "peach.*parquet", full.names = FALSE))
 #' @testexamples
 #' expect_equal(length(lf), 5)

--- a/R/Purple.R
+++ b/R/Purple.R
@@ -8,7 +8,7 @@
 #' odir <- tempdir()
 #' id <- "purple_run1"
 #' obj <- cls$new(indir)
-#' obj$nemofy(odir = odir, format = "parquet", input_id = id)
+#' obj$nemofy(diro = odir, format = "parquet", input_id = id)
 #' (lf <- list.files(odir, pattern = "purple.*parquet", full.names = FALSE))
 #' @testexamples
 #' expect_equal(length(lf), 11)

--- a/R/Sage.R
+++ b/R/Sage.R
@@ -8,7 +8,7 @@
 #' odir <- tempdir()
 #' id <- "sage_run1"
 #' obj <- cls$new(indir)
-#' obj$nemofy(odir = odir, format = "parquet", input_id = id)
+#' obj$nemofy(diro = odir, format = "parquet", input_id = id)
 #' (lf <- list.files(odir, pattern = "sage.*parquet", full.names = FALSE))
 #' @testexamples
 #' expect_equal(length(lf), 10)

--- a/R/Sigs.R
+++ b/R/Sigs.R
@@ -8,7 +8,7 @@
 #' odir <- tempdir()
 #' id <- "sigs_run1"
 #' obj <- cls$new(indir)
-#' obj$nemofy(odir = odir, format = "parquet", input_id = id)
+#' obj$nemofy(diro = odir, format = "parquet", input_id = id)
 #' (lf <- list.files(odir, pattern = "sigs.*parquet", full.names = FALSE))
 #' @testexamples
 #' expect_equal(length(lf), 2)

--- a/R/Teal.R
+++ b/R/Teal.R
@@ -8,7 +8,7 @@
 #' odir <- tempdir()
 #' id <- "teal_run1"
 #' obj <- cls$new(indir)
-#' obj$nemofy(odir = odir, format = "parquet", input_id = id)
+#' obj$nemofy(diro = odir, format = "parquet", input_id = id)
 #' (lf <- list.files(odir, pattern = "teal.*parquet", full.names = FALSE))
 #' @testexamples
 #' expect_equal(length(lf), 2)

--- a/R/Virusbreakend.R
+++ b/R/Virusbreakend.R
@@ -8,7 +8,7 @@
 #' odir <- tempdir()
 #' id <- "virusbreakend_run1"
 #' obj <- cls$new(indir)
-#' obj$nemofy(odir = odir, format = "parquet", input_id = id)
+#' obj$nemofy(diro = odir, format = "parquet", input_id = id)
 #' (lf <- list.files(odir, pattern = "virusbreakend.*parquet", full.names = FALSE))
 #' @testexamples
 #' expect_equal(length(lf), 1)

--- a/R/Virusinterpreter.R
+++ b/R/Virusinterpreter.R
@@ -8,7 +8,7 @@
 #' odir <- tempdir()
 #' id <- "virusinterpreter_run1"
 #' obj <- cls$new(indir)
-#' obj$nemofy(odir = odir, format = "parquet", input_id = id)
+#' obj$nemofy(diro = odir, format = "parquet", input_id = id)
 #' (lf <- list.files(odir, pattern = "virusinterpreter.*parquet", full.names = FALSE))
 #' @testexamples
 #' expect_equal(length(lf), 1)

--- a/R/Wigits.R
+++ b/R/Wigits.R
@@ -8,7 +8,7 @@
 #' w <- Wigits$new(path)
 #' x <-
 #'   w$nemofy(
-#'     odir = "nogit/test_data",
+#'     diro = "nogit/test_data",
 #'     format = "parquet",
 #'     input_id = "run1"
 #' )

--- a/man/Alignments.Rd
+++ b/man/Alignments.Rd
@@ -12,7 +12,7 @@ indir <- system.file("extdata/oa", package = "tidywigits")
 odir <- tempdir()
 id <- "alignments_run1"
 obj <- cls$new(indir)
-obj$nemofy(odir = odir, format = "parquet", id = id)
+obj$nemofy(diro = odir, format = "parquet", input_id = id)
 (lf <- list.files(odir, pattern = "alignments.*parquet", full.names = FALSE))
 }
 \section{Super class}{

--- a/man/Amber.Rd
+++ b/man/Amber.Rd
@@ -12,7 +12,7 @@ indir <- system.file("extdata/oa", package = "tidywigits")
 odir <- tempdir()
 id <- "amber_run1"
 obj <- cls$new(indir)
-obj$nemofy(odir = odir, format = "parquet", id = id)
+obj$nemofy(diro = odir, format = "parquet", input_id = id)
 (lf <- list.files(odir, pattern = "amber.*parquet", full.names = FALSE))
 }
 \section{Super class}{

--- a/man/Bamtools.Rd
+++ b/man/Bamtools.Rd
@@ -12,7 +12,7 @@ indir <- system.file("extdata/oa", package = "tidywigits")
 odir <- tempdir()
 id <- "bamtools_run1"
 obj <- cls$new(indir)
-obj$nemofy(odir = odir, format = "parquet", id = id)
+obj$nemofy(diro = odir, format = "parquet", input_id = id)
 (lf <- list.files(odir, pattern = "bamtools.*parquet", full.names = FALSE))
 }
 \section{Super class}{

--- a/man/Chord.Rd
+++ b/man/Chord.Rd
@@ -12,7 +12,7 @@ indir <- system.file("extdata/oa", package = "tidywigits")
 odir <- tempdir()
 id <- "chord_run1"
 obj <- cls$new(indir)
-obj$nemofy(odir = odir, format = "parquet", id = id)
+obj$nemofy(diro = odir, format = "parquet", input_id = id)
 (lf <- list.files(odir, pattern = "chord.*parquet", full.names = FALSE))
 }
 \section{Super class}{

--- a/man/Cider.Rd
+++ b/man/Cider.Rd
@@ -12,7 +12,7 @@ indir <- system.file("extdata/oa", package = "tidywigits")
 odir <- tempdir()
 id <- "cider_run1"
 obj <- cls$new(indir)
-obj$nemofy(odir = odir, format = "parquet", id = id)
+obj$nemofy(diro = odir, format = "parquet", input_id = id)
 (lf <- list.files(odir, pattern = "cider.*parquet", full.names = FALSE))
 }
 \section{Super class}{

--- a/man/Cobalt.Rd
+++ b/man/Cobalt.Rd
@@ -12,7 +12,7 @@ indir <- system.file("extdata/oa", package = "tidywigits")
 odir <- tempdir()
 id <- "cobalt_run1"
 obj <- cls$new(indir)
-obj$nemofy(odir = odir, format = "parquet", id = id)
+obj$nemofy(diro = odir, format = "parquet", input_id = id)
 (lf <- list.files(odir, pattern = "cobalt.*parquet", full.names = FALSE))
 }
 \section{Super class}{

--- a/man/Cuppa.Rd
+++ b/man/Cuppa.Rd
@@ -12,7 +12,7 @@ indir <- system.file("extdata/oa", package = "tidywigits")
 odir <- tempdir()
 id <- "cuppa_run1"
 obj <- cls$new(indir)
-obj$nemofy(odir = odir, format = "parquet", id = id)
+obj$nemofy(diro = odir, format = "parquet", input_id = id)
 (lf <- list.files(odir, pattern = "cuppa.*parquet", full.names = FALSE))
 }
 \section{Super class}{

--- a/man/Esvee.Rd
+++ b/man/Esvee.Rd
@@ -12,7 +12,7 @@ indir <- system.file("extdata/oa", package = "tidywigits")
 odir <- tempdir()
 id <- "esvee_run1"
 obj <- cls$new(indir)
-obj$nemofy(odir = odir, format = "parquet", id = id)
+obj$nemofy(diro = odir, format = "parquet", input_id = id)
 (lf <- list.files(odir, pattern = "cobalt.*parquet", full.names = FALSE))
 #TODO: add esvee test data
 }

--- a/man/Flagstats.Rd
+++ b/man/Flagstats.Rd
@@ -12,7 +12,7 @@ indir <- system.file("extdata/oa", package = "tidywigits")
 odir <- tempdir()
 id <- "flagstats_run1"
 obj <- cls$new(indir)
-obj$nemofy(odir = odir, format = "parquet", id = id)
+obj$nemofy(diro = odir, format = "parquet", input_id = id)
 (lf <- list.files(odir, pattern = "parquet", full.names = FALSE))
 #TODO: add flagstats test data
 }

--- a/man/Isofox.Rd
+++ b/man/Isofox.Rd
@@ -12,7 +12,7 @@ indir <- system.file("extdata/oa", package = "tidywigits")
 odir <- tempdir()
 id <- "isofox_run1"
 obj <- cls$new(indir)
-obj$nemofy(odir = odir, format = "parquet", id = id)
+obj$nemofy(diro = odir, format = "parquet", input_id = id)
 (lf <- list.files(odir, pattern = "parquet", full.names = FALSE))
 #TODO: add isofox test data
 }

--- a/man/Lilac.Rd
+++ b/man/Lilac.Rd
@@ -12,7 +12,7 @@ indir <- system.file("extdata/oa", package = "tidywigits")
 odir <- tempdir()
 id <- "lilac_run1"
 obj <- cls$new(indir)
-obj$nemofy(odir = odir, format = "parquet", id = id)
+obj$nemofy(diro = odir, format = "parquet", input_id = id)
 (lf <- list.files(odir, pattern = "lilac.*parquet", full.names = FALSE))
 }
 \section{Super class}{

--- a/man/Linx.Rd
+++ b/man/Linx.Rd
@@ -12,7 +12,7 @@ indir <- system.file("extdata/oa", package = "tidywigits")
 odir <- tempdir()
 id <- "linx_run1"
 obj <- cls$new(indir)
-obj$nemofy(odir = odir, format = "parquet", id = id)
+obj$nemofy(diro = odir, format = "parquet", input_id = id)
 (lf <- list.files(odir, pattern = "linx.*parquet", full.names = FALSE))
 }
 \section{Super class}{

--- a/man/Neo.Rd
+++ b/man/Neo.Rd
@@ -12,7 +12,7 @@ indir <- system.file("extdata/oa", package = "tidywigits")
 odir <- tempdir()
 id <- "neo_run1"
 obj <- cls$new(indir)
-obj$nemofy(odir = odir, format = "parquet", id = id)
+obj$nemofy(diro = odir, format = "parquet", input_id = id)
 (lf <- list.files(odir, pattern = "neo.*parquet", full.names = FALSE))
 }
 \section{Super class}{

--- a/man/Peach.Rd
+++ b/man/Peach.Rd
@@ -12,7 +12,7 @@ indir <- system.file("extdata/oa", package = "tidywigits")
 odir <- tempdir()
 id <- "peach_run1"
 obj <- cls$new(indir)
-obj$nemofy(odir = odir, format = "parquet", id = id)
+obj$nemofy(diro = odir, format = "parquet", input_id = id)
 (lf <- list.files(odir, pattern = "peach.*parquet", full.names = FALSE))
 }
 \section{Super class}{

--- a/man/Purple.Rd
+++ b/man/Purple.Rd
@@ -12,7 +12,7 @@ indir <- system.file("extdata/oa", package = "tidywigits")
 odir <- tempdir()
 id <- "purple_run1"
 obj <- cls$new(indir)
-obj$nemofy(odir = odir, format = "parquet", id = id)
+obj$nemofy(diro = odir, format = "parquet", input_id = id)
 (lf <- list.files(odir, pattern = "purple.*parquet", full.names = FALSE))
 }
 \section{Super class}{

--- a/man/Sage.Rd
+++ b/man/Sage.Rd
@@ -12,7 +12,7 @@ indir <- system.file("extdata/oa", package = "tidywigits")
 odir <- tempdir()
 id <- "sage_run1"
 obj <- cls$new(indir)
-obj$nemofy(odir = odir, format = "parquet", id = id)
+obj$nemofy(diro = odir, format = "parquet", input_id = id)
 (lf <- list.files(odir, pattern = "sage.*parquet", full.names = FALSE))
 }
 \section{Super class}{

--- a/man/Sigs.Rd
+++ b/man/Sigs.Rd
@@ -12,7 +12,7 @@ indir <- system.file("extdata/oa", package = "tidywigits")
 odir <- tempdir()
 id <- "sigs_run1"
 obj <- cls$new(indir)
-obj$nemofy(odir = odir, format = "parquet", id = id)
+obj$nemofy(diro = odir, format = "parquet", input_id = id)
 (lf <- list.files(odir, pattern = "sigs.*parquet", full.names = FALSE))
 }
 \section{Super class}{

--- a/man/Teal.Rd
+++ b/man/Teal.Rd
@@ -12,7 +12,7 @@ indir <- system.file("extdata/oa", package = "tidywigits")
 odir <- tempdir()
 id <- "teal_run1"
 obj <- cls$new(indir)
-obj$nemofy(odir = odir, format = "parquet", id = id)
+obj$nemofy(diro = odir, format = "parquet", input_id = id)
 (lf <- list.files(odir, pattern = "teal.*parquet", full.names = FALSE))
 }
 \section{Super class}{

--- a/man/Virusbreakend.Rd
+++ b/man/Virusbreakend.Rd
@@ -12,7 +12,7 @@ indir <- system.file("extdata/oa", package = "tidywigits")
 odir <- tempdir()
 id <- "virusbreakend_run1"
 obj <- cls$new(indir)
-obj$nemofy(odir = odir, format = "parquet", id = id)
+obj$nemofy(diro = odir, format = "parquet", input_id = id)
 (lf <- list.files(odir, pattern = "virusbreakend.*parquet", full.names = FALSE))
 }
 \section{Super class}{

--- a/man/Virusinterpreter.Rd
+++ b/man/Virusinterpreter.Rd
@@ -12,7 +12,7 @@ indir <- system.file("extdata/oa", package = "tidywigits")
 odir <- tempdir()
 id <- "virusinterpreter_run1"
 obj <- cls$new(indir)
-obj$nemofy(odir = odir, format = "parquet", id = id)
+obj$nemofy(diro = odir, format = "parquet", input_id = id)
 (lf <- list.files(odir, pattern = "virusinterpreter.*parquet", full.names = FALSE))
 }
 \section{Super class}{

--- a/man/Wigits.Rd
+++ b/man/Wigits.Rd
@@ -12,9 +12,9 @@ path <- here::here("nogit/oa_v2")
 w <- Wigits$new(path)
 x <-
   w$nemofy(
-    odir = "nogit/test_data",
+    diro = "nogit/test_data",
     format = "parquet",
-    id = "run1"
+    input_id = "run1"
 )
 dbconn <- DBI::dbConnect(
   drv = RPostgres::Postgres(),
@@ -24,7 +24,7 @@ dbconn <- DBI::dbConnect(
 x <-
   w$nemofy(
     format = "db",
-    id = "runABC456",
+    input_id = "runABC456",
     dbconn = dbconn
 )
 DBI::dbDisconnect(dbconn)
@@ -44,6 +44,7 @@ DBI::dbDisconnect(dbconn)
 <details><summary>Inherited methods</summary>
 <ul>
 <li><span class="pkg-link" data-pkg="nemo" data-topic="Workflow" data-id="filter_files"><a href='../../nemo/html/Workflow.html#method-Workflow-filter_files'><code>nemo::Workflow$filter_files()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="nemo" data-topic="Workflow" data-id="get_metadata"><a href='../../nemo/html/Workflow.html#method-Workflow-get_metadata'><code>nemo::Workflow$get_metadata()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="nemo" data-topic="Workflow" data-id="get_raw_schemas_all"><a href='../../nemo/html/Workflow.html#method-Workflow-get_raw_schemas_all'><code>nemo::Workflow$get_raw_schemas_all()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="nemo" data-topic="Workflow" data-id="get_tbls"><a href='../../nemo/html/Workflow.html#method-Workflow-get_tbls'><code>nemo::Workflow$get_tbls()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="nemo" data-topic="Workflow" data-id="get_tidy_schemas_all"><a href='../../nemo/html/Workflow.html#method-Workflow-get_tidy_schemas_all'><code>nemo::Workflow$get_tidy_schemas_all()</code></a></span></li>

--- a/tests/testthat/test-roxytest-testexamples-Alignments.R
+++ b/tests/testthat/test-roxytest-testexamples-Alignments.R
@@ -9,7 +9,7 @@ test_that("Function Alignments() @ L16", {
   odir <- tempdir()
   id <- "alignments_run1"
   obj <- cls$new(indir)
-  obj$nemofy(odir = odir, format = "parquet", id = id)
+  obj$nemofy(diro = odir, format = "parquet", input_id = id)
   (lf <- list.files(odir, pattern = "alignments.*parquet", full.names = FALSE))
   expect_equal(grepv("parquet", lf), "sample1_alignments_dupfreq.parquet")
 })

--- a/tests/testthat/test-roxytest-testexamples-Amber.R
+++ b/tests/testthat/test-roxytest-testexamples-Amber.R
@@ -9,7 +9,7 @@ test_that("Function Amber() @ L16", {
   odir <- tempdir()
   id <- "amber_run1"
   obj <- cls$new(indir)
-  obj$nemofy(odir = odir, format = "parquet", id = id)
+  obj$nemofy(diro = odir, format = "parquet", input_id = id)
   (lf <- list.files(odir, pattern = "amber.*parquet", full.names = FALSE))
   expect_equal(length(lf), 4)
 })

--- a/tests/testthat/test-roxytest-testexamples-Bamtools.R
+++ b/tests/testthat/test-roxytest-testexamples-Bamtools.R
@@ -9,7 +9,7 @@ test_that("Function Bamtools() @ L16", {
   odir <- tempdir()
   id <- "bamtools_run1"
   obj <- cls$new(indir)
-  obj$nemofy(odir = odir, format = "parquet", id = id)
+  obj$nemofy(diro = odir, format = "parquet", input_id = id)
   (lf <- list.files(odir, pattern = "bamtools.*parquet", full.names = FALSE))
   expect_equal(length(lf), 11)
 })

--- a/tests/testthat/test-roxytest-testexamples-Chord.R
+++ b/tests/testthat/test-roxytest-testexamples-Chord.R
@@ -9,7 +9,7 @@ test_that("Function Chord() @ L16", {
   odir <- tempdir()
   id <- "chord_run1"
   obj <- cls$new(indir)
-  obj$nemofy(odir = odir, format = "parquet", id = id)
+  obj$nemofy(diro = odir, format = "parquet", input_id = id)
   (lf <- list.files(odir, pattern = "chord.*parquet", full.names = FALSE))
   expect_equal(length(lf), 2)
 })

--- a/tests/testthat/test-roxytest-testexamples-Cider.R
+++ b/tests/testthat/test-roxytest-testexamples-Cider.R
@@ -9,7 +9,7 @@ test_that("Function Cider() @ L16", {
   odir <- tempdir()
   id <- "cider_run1"
   obj <- cls$new(indir)
-  obj$nemofy(odir = odir, format = "parquet", id = id)
+  obj$nemofy(diro = odir, format = "parquet", input_id = id)
   (lf <- list.files(odir, pattern = "cider.*parquet", full.names = FALSE))
   expect_equal(length(lf), 3)
 })

--- a/tests/testthat/test-roxytest-testexamples-Cobalt.R
+++ b/tests/testthat/test-roxytest-testexamples-Cobalt.R
@@ -9,7 +9,7 @@ test_that("Function Cobalt() @ L16", {
   odir <- tempdir()
   id <- "cobalt_run1"
   obj <- cls$new(indir)
-  obj$nemofy(odir = odir, format = "parquet", id = id)
+  obj$nemofy(diro = odir, format = "parquet", input_id = id)
   (lf <- list.files(odir, pattern = "cobalt.*parquet", full.names = FALSE))
   expect_equal(length(lf), 5)
 })

--- a/tests/testthat/test-roxytest-testexamples-Cuppa.R
+++ b/tests/testthat/test-roxytest-testexamples-Cuppa.R
@@ -9,7 +9,7 @@ test_that("Function Cuppa() @ L16", {
   odir <- tempdir()
   id <- "cuppa_run1"
   obj <- cls$new(indir)
-  obj$nemofy(odir = odir, format = "parquet", id = id)
+  obj$nemofy(diro = odir, format = "parquet", input_id = id)
   (lf <- list.files(odir, pattern = "cuppa.*parquet", full.names = FALSE))
   expect_equal(length(lf), 3)
 })

--- a/tests/testthat/test-roxytest-testexamples-Lilac.R
+++ b/tests/testthat/test-roxytest-testexamples-Lilac.R
@@ -9,7 +9,7 @@ test_that("Function Lilac() @ L16", {
   odir <- tempdir()
   id <- "lilac_run1"
   obj <- cls$new(indir)
-  obj$nemofy(odir = odir, format = "parquet", id = id)
+  obj$nemofy(diro = odir, format = "parquet", input_id = id)
   (lf <- list.files(odir, pattern = "lilac.*parquet", full.names = FALSE))
   expect_equal(length(lf), 2)
 })

--- a/tests/testthat/test-roxytest-testexamples-Linx.R
+++ b/tests/testthat/test-roxytest-testexamples-Linx.R
@@ -9,7 +9,7 @@ test_that("Function Linx() @ L16", {
   odir <- tempdir()
   id <- "linx_run1"
   obj <- cls$new(indir)
-  obj$nemofy(odir = odir, format = "parquet", id = id)
+  obj$nemofy(diro = odir, format = "parquet", input_id = id)
   (lf <- list.files(odir, pattern = "linx.*parquet", full.names = FALSE))
   expect_equal(length(lf), 20)
 })

--- a/tests/testthat/test-roxytest-testexamples-Neo.R
+++ b/tests/testthat/test-roxytest-testexamples-Neo.R
@@ -9,7 +9,7 @@ test_that("Function Neo() @ L16", {
   odir <- tempdir()
   id <- "neo_run1"
   obj <- cls$new(indir)
-  obj$nemofy(odir = odir, format = "parquet", id = id)
+  obj$nemofy(diro = odir, format = "parquet", input_id = id)
   (lf <- list.files(odir, pattern = "neo.*parquet", full.names = FALSE))
   expect_equal(length(lf), 2)
 })

--- a/tests/testthat/test-roxytest-testexamples-Peach.R
+++ b/tests/testthat/test-roxytest-testexamples-Peach.R
@@ -9,7 +9,7 @@ test_that("Function Peach() @ L16", {
   odir <- tempdir()
   id <- "peach_run1"
   obj <- cls$new(indir)
-  obj$nemofy(odir = odir, format = "parquet", id = id)
+  obj$nemofy(diro = odir, format = "parquet", input_id = id)
   (lf <- list.files(odir, pattern = "peach.*parquet", full.names = FALSE))
   expect_equal(length(lf), 5)
 })

--- a/tests/testthat/test-roxytest-testexamples-Purple.R
+++ b/tests/testthat/test-roxytest-testexamples-Purple.R
@@ -9,7 +9,7 @@ test_that("Function Purple() @ L16", {
   odir <- tempdir()
   id <- "purple_run1"
   obj <- cls$new(indir)
-  obj$nemofy(odir = odir, format = "parquet", id = id)
+  obj$nemofy(diro = odir, format = "parquet", input_id = id)
   (lf <- list.files(odir, pattern = "purple.*parquet", full.names = FALSE))
   expect_equal(length(lf), 11)
 })

--- a/tests/testthat/test-roxytest-testexamples-Sage.R
+++ b/tests/testthat/test-roxytest-testexamples-Sage.R
@@ -9,7 +9,7 @@ test_that("Function Sage() @ L16", {
   odir <- tempdir()
   id <- "sage_run1"
   obj <- cls$new(indir)
-  obj$nemofy(odir = odir, format = "parquet", id = id)
+  obj$nemofy(diro = odir, format = "parquet", input_id = id)
   (lf <- list.files(odir, pattern = "sage.*parquet", full.names = FALSE))
   expect_equal(length(lf), 10)
 })

--- a/tests/testthat/test-roxytest-testexamples-Sigs.R
+++ b/tests/testthat/test-roxytest-testexamples-Sigs.R
@@ -9,7 +9,7 @@ test_that("Function Sigs() @ L16", {
   odir <- tempdir()
   id <- "sigs_run1"
   obj <- cls$new(indir)
-  obj$nemofy(odir = odir, format = "parquet", id = id)
+  obj$nemofy(diro = odir, format = "parquet", input_id = id)
   (lf <- list.files(odir, pattern = "sigs.*parquet", full.names = FALSE))
   expect_equal(length(lf), 2)
 })

--- a/tests/testthat/test-roxytest-testexamples-Teal.R
+++ b/tests/testthat/test-roxytest-testexamples-Teal.R
@@ -9,7 +9,7 @@ test_that("Function Teal() @ L16", {
   odir <- tempdir()
   id <- "teal_run1"
   obj <- cls$new(indir)
-  obj$nemofy(odir = odir, format = "parquet", id = id)
+  obj$nemofy(diro = odir, format = "parquet", input_id = id)
   (lf <- list.files(odir, pattern = "teal.*parquet", full.names = FALSE))
   expect_equal(length(lf), 2)
 })

--- a/tests/testthat/test-roxytest-testexamples-Virusbreakend.R
+++ b/tests/testthat/test-roxytest-testexamples-Virusbreakend.R
@@ -9,7 +9,7 @@ test_that("Function Virusbreakend() @ L16", {
   odir <- tempdir()
   id <- "virusbreakend_run1"
   obj <- cls$new(indir)
-  obj$nemofy(odir = odir, format = "parquet", id = id)
+  obj$nemofy(diro = odir, format = "parquet", input_id = id)
   (lf <- list.files(odir, pattern = "virusbreakend.*parquet", full.names = FALSE))
   expect_equal(length(lf), 1)
 })

--- a/tests/testthat/test-roxytest-testexamples-Virusinterpreter.R
+++ b/tests/testthat/test-roxytest-testexamples-Virusinterpreter.R
@@ -9,7 +9,7 @@ test_that("Function Virusinterpreter() @ L16", {
   odir <- tempdir()
   id <- "virusinterpreter_run1"
   obj <- cls$new(indir)
-  obj$nemofy(odir = odir, format = "parquet", id = id)
+  obj$nemofy(diro = odir, format = "parquet", input_id = id)
   (lf <- list.files(odir, pattern = "virusinterpreter.*parquet", full.names = FALSE))
   expect_equal(length(lf), 1)
 })


### PR DESCRIPTION
Changed to using `diro` and `input_id` in `nemofy`. I'm so over naming things..