### PR TITLE
GHA: sync DVC for README render when bumping

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -16,4 +16,5 @@ jobs:
     with:
       pkg_name: tidywigits
       pkg_version: ${{ inputs.version }}
+      dvc: true
     secrets: inherit


### PR DESCRIPTION
Need to sync DVC data when rendering the README for the bump workflow.