### PR TITLE
Conda recipe fix

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -24,7 +24,6 @@ filename = "DESCRIPTION"
 search = "Version: {current_version}"
 replace = "Version: {new_version}"
 
-
 [[tool.bumpversion.files]]
 filename = "deploy/conda/recipe/recipe.yaml"
 search = "version: {current_version}"
@@ -32,6 +31,11 @@ replace = "version: {new_version}"
 
 [[tool.bumpversion.files]]
 filename = "deploy/conda/env/yaml/tidywigits.yaml"
+search = "r-tidywigits =={current_version}"
+replace = "r-tidywigits =={new_version}"
+
+[[tool.bumpversion.files]]
+filename = "deploy/conda/env/yaml/pkgdown.yaml"
 search = "r-tidywigits =={current_version}"
 replace = "r-tidywigits =={new_version}"
 

--- a/deploy/conda/env/yaml/condabuild.yaml
+++ b/deploy/conda/env/yaml/condabuild.yaml
@@ -1,5 +1,4 @@
 name: condabuild_env
-
 channels:
   - conda-forge
 dependencies:

--- a/deploy/conda/env/yaml/pkgdown.yaml
+++ b/deploy/conda/env/yaml/pkgdown.yaml
@@ -4,7 +4,7 @@ channels:
   - tidywf
   - conda-forge
 dependencies:
-  - r-tidywigits
+  - r-tidywigits ==0.0.7.9004 # bump
   - r-pkgdown
   - r-quarto
   - quarto
@@ -13,4 +13,3 @@ dependencies:
   - plantuml
   - r-htmltools
   - r-reactable
-  - nodejs

--- a/deploy/conda/recipe/recipe.yaml
+++ b/deploy/conda/recipe/recipe.yaml
@@ -16,20 +16,6 @@ build:
 requirements:
   host:
     - r-base
-    - r-dplyr
-    - r-fs
-    - r-glue
-    - r-knitr
-    - r-nemo
-    - r-purrr
-    - r-r6
-    - r-readr
-    - r-rlang
-    - r-rmarkdown
-    - r-stringr
-    - r-tibble
-    - r-tidyr
-    - r-yaml
   run:
     - r-base
     - r-dplyr
@@ -55,7 +41,7 @@ tests:
 about:
   homepage: https://github.com/tidywf/tidywigits
   summary: WiGiTS workflow tidying
-  description: WiGiTS workflow tidying
+  description: Provides tools for tidying and exploring outputs from the WiGiTS bioinformatic pipeline suite.
   license: MIT
   license_file: LICENSE
   repository: https://github.com/tidywf/tidywigits


### PR DESCRIPTION
- Removing non-base requirements.host dependencies since those are not actually required
- Keeping the tidywigits pin in the pkgdown conda env