### PR TITLE
OA v3: Lilac update

### DIFF
--- a/R/Lilac.R
+++ b/R/Lilac.R
@@ -3,25 +3,28 @@
 #' @description
 #' Lilac file parsing and manipulation.
 #' @examples
-#' cls <- Lilac
-#' indir <- system.file("extdata/oa", package = "tidywigits")
+#' cls <- Lilac; tool <- "lilac"
+#' indir <- system.file("extdata/oa", tool, package = "tidywigits")
 #' odir <- tempdir()
-#' id <- "lilac_run1"
+#' id <- paste0(tool, "_run1")
 #' obj <- cls$new(indir)
 #' obj$run(output_dir = odir, format = "parquet", input_id = id)
 #' (lf <- list.files(odir, pattern = "lilac_.*parquet", full.names = FALSE))
 #' @testexamples
-#' expect_equal(length(lf), 2)
-#' qc <- arrow::read_parquet(file.path(odir, grep("lilac_qc", lf, value = TRUE)))
-#' expect_named(qc, c("input_id", "status", "score_margin", "next_solution_alleles",
-#'   "median_base_quality", "hla_y_allele", "discarded_indels", "discarded_indel_max_frags",
-#'   "discarded_alignment_fragments", "a_low_coverage_bases", "b_low_coverage_bases",
-#'   "c_low_coverage_bases", "a_types", "b_types", "c_types", "total_fragments",
-#'   "fitted_fragments", "unmatched_fragments", "uninformative_fragments", "hla_y_fragments",
-#'   "percent_unique", "percent_shared", "percent_wildcard", "unused_amino_acids",
-#'   "unused_amino_acid_max_frags", "unused_haplotypes", "unused_haplotype_max_frags",
-#'   "somatic_variants_matched", "somatic_variants_unmatched"))
-#' expect_equal(nrow(qc), 1L)
+#' expect_equal(length(lf), 4)
+#' qcs <- lapply(grep("lilac_qc", lf, value = TRUE),
+#'   function(f) names(arrow::read_parquet(file.path(odir, f))))
+#' qc_new <- Filter(function(n) "low_coverage_bases" %in% n, qcs)[[1]]
+#' qc_old <- Filter(function(n) "a_low_coverage_bases" %in% n, qcs)[[1]]
+#' expect_true(all(c("genes", "low_coverage_bases", "gene_types") %in% qc_new))
+#' expect_false(any(c("a_low_coverage_bases", "a_types") %in% qc_new))
+#' expect_true(all(c("a_low_coverage_bases", "b_low_coverage_bases", "c_low_coverage_bases",
+#'   "a_types", "b_types", "c_types") %in% qc_old))
+#' expect_false(any(c("genes", "low_coverage_bases", "gene_types") %in% qc_old))
+#' sms <- lapply(grep("lilac_summary", lf, value = TRUE),
+#'   function(f) names(arrow::read_parquet(file.path(odir, f))))
+#' expect_true(any(vapply(sms, function(n) "genes" %in% n, logical(1))))
+#' expect_true(any(vapply(sms, function(n) !("genes" %in% n), logical(1))))
 #' @export
 Lilac <- R6::R6Class(
   "Lilac",

--- a/inst/config/tools/lilac/schema.yaml
+++ b/inst/config/tools/lilac/schema.yaml
@@ -4,243 +4,263 @@ tables:
     pattern: "\\.lilac\\.tsv$"
     ftype: 'tsv'
     columns:
+      - raw: 'Genes'
+        tidy: 'genes'
+        type: 'char'
+        description: 'gene(s) for the allele'
+        versions: ['latest']
       - raw: 'Allele'
         tidy: 'allele'
         type: 'char'
         description: 'Allele ID'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'RefTotal'
         tidy: 'ref_total'
         type: 'float'
         description: 'Total assigned fragments from reference BAM'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'RefUnique'
         tidy: 'ref_unique'
         type: 'float'
         description: 'Fragments uniquely assigned to allele'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'RefShared'
         tidy: 'ref_shared'
         type: 'float'
         description: 'Fragments assigned to ref allele and others in this solution'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'RefWild'
         tidy: 'ref_wild'
         type: 'float'
         description: 'Fragments matched to a wildcard allele'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'TumorTotal'
         tidy: 'tumor_total'
         type: 'float'
         description: 'Total assigned fragments from tumor BAM'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'TumorUnique'
         tidy: 'tumor_unique'
         type: 'float'
         description: 'Fragments uniquely assigned to allele'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'TumorShared'
         tidy: 'tumor_shared'
         type: 'float'
         description: 'Fragments assigned to allele and others in this solution'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'TumorWild'
         tidy: 'tumor_wild'
         type: 'float'
         description: 'Fragments matched to a wildcard allele'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'RnaTotal'
         tidy: 'rna_total'
         type: 'float'
         description: 'Total assigned fragments from RNA BAM'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'RnaUnique'
         tidy: 'rna_unique'
         type: 'float'
         description: 'Fragments uniquely assigned to allele'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'RnaShared'
         tidy: 'rna_shared'
         type: 'float'
         description: 'Fragments assigned to allele and others in this solution'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'RnaWild'
         tidy: 'rna_wild'
         type: 'float'
         description: 'Fragments matched to a wildcard allele'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'TumorCopyNumber'
         tidy: 'tumor_cn'
         type: 'float'
         description: 'Copy number from Tumor/Ref fragment ratio and Purple copy number'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'SomaticMissense'
         tidy: 'somatic_missense'
         type: 'float'
         description: 'Matched missense variants'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'SomaticNonsenseOrFrameshift'
         tidy: 'somatic_nonsense_or_frameshift'
         type: 'float'
         description: 'Matched nonsense or frameshift variants'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'SomaticSplice'
         tidy: 'somatic_splice'
         type: 'float'
         description: 'Matched splice variants'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'SomaticSynonymous'
         tidy: 'somatic_synonymous'
         type: 'float'
         description: 'Matched synonymous variants'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'SomaticInframeIndel'
         tidy: 'somatic_inframe_indel'
         type: 'float'
         description: 'Matched inframe indels'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
   qc:
     description: 'Lilac QC.'
     pattern: "\\.lilac\\.qc\\.tsv$"
     ftype: 'tsv'
     columns:
+      - raw: 'Genes'
+        tidy: 'genes'
+        type: 'char'
+        description: 'gene(s) for the QC record'
+        versions: ['latest']
       - raw: 'Status'
         tidy: 'status'
         type: 'char'
         description: 'Either PASS or 1 or more warnings'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'ScoreMargin'
         tidy: 'score_margin'
         type: 'float'
         description: 'Difference in score to second-top solution'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'NextSolutionAlleles'
         tidy: 'next_solution_alleles'
         type: 'char'
         description: 'Allele difference in second-top solution'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'MedianBaseQuality'
         tidy: 'median_base_quality'
         type: 'float'
         description: 'Median base quality across all coding bases from all fragments'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'HlaYAllele'
         tidy: 'hla_y_allele'
         type: 'char'
         description: 'HLA-Y allele detected if present, else NONE'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'DiscardedIndels'
         tidy: 'discarded_indels'
         type: 'float'
         description: 'Discarded fragments due to unknown INDELs'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'DiscardedIndelMaxFrags'
         tidy: 'discarded_indel_max_frags'
         type: 'float'
         description: 'Maximum fragment support for an indel detected but not present in any known allele'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'DiscardedAlignmentFragments'
         tidy: 'discarded_alignment_fragments'
         type: 'float'
         description: 'Fragments discarded because 1 read aligns more than 1000 bases from a HLA A,B or C gene'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'A_LowCoverageBases'
         tidy: 'a_low_coverage_bases'
         type: 'float'
         description: 'Number of bases with less than 15-depth coverage across all coding bases'
-        versions: ['latest']
+        versions: ['v1.7.1']
       - raw: 'B_LowCoverageBases'
         tidy: 'b_low_coverage_bases'
         type: 'float'
         description: 'Number of bases with less than 15-depth coverage across all coding bases'
-        versions: ['latest']
+        versions: ['v1.7.1']
       - raw: 'C_LowCoverageBases'
         tidy: 'c_low_coverage_bases'
         type: 'float'
         description: 'Number of bases with less than 15-depth coverage across all coding bases'
+        versions: ['v1.7.1']
+      - raw: 'LowCoverageBases'
+        tidy: 'low_coverage_bases'
+        type: 'char'
+        description: 'per-gene number of bases with less than 15-depth coverage (gene=count)'
         versions: ['latest']
       - raw: 'ATypes'
         tidy: 'a_types'
         type: 'float'
         description: '# of distinct HLA-A alleles fitted (0,1 or 2)'
-        versions: ['latest']
+        versions: ['v1.7.1']
       - raw: 'BTypes'
         tidy: 'b_types'
         type: 'float'
         description: '# of distinct HLA-B alleles fitted (0,1 or 2)'
-        versions: ['latest']
+        versions: ['v1.7.1']
       - raw: 'CTypes'
         tidy: 'c_types'
         type: 'float'
         description: '# of distinct HLA-C alleles fitted (0,1 or 2)'
+        versions: ['v1.7.1']
+      - raw: 'geneTypes'
+        tidy: 'gene_types'
+        type: 'char'
+        description: 'per-gene # of distinct alleles fitted (gene=count)'
         versions: ['latest']
       - raw: 'TotalFragments'
         tidy: 'total_fragments'
         type: 'float'
         description: 'Total of fragments overlapping a coding base of HLA-A, HLA-B or HLA-C with MAPQ >=1'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'FittedFragments'
         tidy: 'fitted_fragments'
         type: 'float'
         description: 'Total fragments assigned to fitted alleles'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'UnmatchedFragments'
         tidy: 'unmatched_fragments'
         type: 'float'
         description: 'Fragment that do not match any allele exactly in solution at all heterozygous location'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'UninformativeFragments'
         tidy: 'uninformative_fragments'
         type: 'float'
         description: 'Fragments that do not overlap any heterozygous location considered in evidence phase'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'HlaYFragments'
         tidy: 'hla_y_fragments'
         type: 'float'
         description: 'Fragments excluded from fit due to allocation to assignment to HLA-Y'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'PercentUnique'
         tidy: 'percent_unique'
         type: 'float'
         description: 'Percentage of fitted fragments that are uniquely assigned to 1 allele'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'PercentShared'
         tidy: 'percent_shared'
         type: 'float'
         description: 'Percentage of fitted fragments allocated across multiple alleles'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'PercentWildcard'
         tidy: 'percent_wildcard'
         type: 'float'
         description: 'Percentage of fitted fragments uniquely assigned to wildcard regions'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'UnusedAminoAcids'
         tidy: 'unused_amino_acids'
         type: 'float'
         description: '# of amino acids detected with at least 3 fragments support but not present in final allele solution set'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'UnusedAminoAcidMaxFrags'
         tidy: 'unused_amino_acid_max_frags'
         type: 'float'
         description: 'Maximum fragments support for an unmatched amino acid not present in the final allele solution set'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'UnusedHaplotypes'
         tidy: 'unused_haplotypes'
         type: 'float'
         description: '# of haplotypes phased with at least 3 fragments support but not present in final allele solution set'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'UnusedHaplotypeMaxFrags'
         tidy: 'unused_haplotype_max_frags'
         type: 'float'
         description: 'Maximum support for an unmatched haplotype not present in final allele solution set'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'SomaticVariantsMatched'
         tidy: 'somatic_variants_matched'
         type: 'float'
         description: 'Somatic variants supported by solution allele'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']
       - raw: 'SomaticVariantsUnmatched'
         tidy: 'somatic_variants_unmatched'
         type: 'float'
         description: 'Somatic variants not supported by solution allele'
-        versions: ['latest']
+        versions: ['v1.7.1', 'latest']

--- a/inst/extdata/oa/lilac/sample1.lilac.candidates.coverage.tsv.dvc
+++ b/inst/extdata/oa/lilac/sample1.lilac.candidates.coverage.tsv.dvc
@@ -1,5 +1,0 @@
-outs:
-- md5: 5eb9bacd83c1753e163c94d6919e2ec4
-  size: 491
-  hash: md5
-  path: sample1.lilac.candidates.coverage.tsv

--- a/inst/extdata/oa/lilac/sample1.lilac.qc.tsv.dvc
+++ b/inst/extdata/oa/lilac/sample1.lilac.qc.tsv.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 7c9993ef5c385cfcb9ca7b73548c7754
-  size: 570
+- md5: 1c3c412781f7ec80d64df21c001b53b2
+  size: 953
   hash: md5
   path: sample1.lilac.qc.tsv

--- a/inst/extdata/oa/lilac/sample1.lilac.tsv.dvc
+++ b/inst/extdata/oa/lilac/sample1.lilac.tsv.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 2a4b51694266d1306d949555b006bd52
-  size: 682
+- md5: 994bf652d1b6375c6a2ac6965d31ee46
+  size: 1043
   hash: md5
   path: sample1.lilac.tsv

--- a/inst/extdata/oa/lilac/v1.7.1/.gitignore
+++ b/inst/extdata/oa/lilac/v1.7.1/.gitignore
@@ -1,0 +1,2 @@
+/sample1.lilac.qc.tsv
+/sample1.lilac.tsv

--- a/inst/extdata/oa/lilac/v1.7.1/sample1.lilac.qc.tsv.dvc
+++ b/inst/extdata/oa/lilac/v1.7.1/sample1.lilac.qc.tsv.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 7c9993ef5c385cfcb9ca7b73548c7754
+  size: 570
+  hash: md5
+  path: sample1.lilac.qc.tsv

--- a/inst/extdata/oa/lilac/v1.7.1/sample1.lilac.tsv.dvc
+++ b/inst/extdata/oa/lilac/v1.7.1/sample1.lilac.tsv.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 2a4b51694266d1306d949555b006bd52
+  size: 682
+  hash: md5
+  path: sample1.lilac.tsv

--- a/man/Lilac.Rd
+++ b/man/Lilac.Rd
@@ -7,10 +7,10 @@
 Lilac file parsing and manipulation.
 }
 \examples{
-cls <- Lilac
-indir <- system.file("extdata/oa", package = "tidywigits")
+cls <- Lilac; tool <- "lilac"
+indir <- system.file("extdata/oa", tool, package = "tidywigits")
 odir <- tempdir()
-id <- "lilac_run1"
+id <- paste0(tool, "_run1")
 obj <- cls$new(indir)
 obj$run(output_dir = odir, format = "parquet", input_id = id)
 (lf <- list.files(odir, pattern = "lilac_.*parquet", full.names = FALSE))

--- a/tests/testthat/test-roxytest-testexamples-Lilac.R
+++ b/tests/testthat/test-roxytest-testexamples-Lilac.R
@@ -2,25 +2,28 @@
 
 # File R/Lilac.R: @testexamples
 
-test_that("Function Lilac() @ L26", {
+test_that("Function Lilac() @ L29", {
   
-  cls <- Lilac
-  indir <- system.file("extdata/oa", package = "tidywigits")
+  cls <- Lilac; tool <- "lilac"
+  indir <- system.file("extdata/oa", tool, package = "tidywigits")
   odir <- tempdir()
-  id <- "lilac_run1"
+  id <- paste0(tool, "_run1")
   obj <- cls$new(indir)
   obj$run(output_dir = odir, format = "parquet", input_id = id)
   (lf <- list.files(odir, pattern = "lilac_.*parquet", full.names = FALSE))
-  expect_equal(length(lf), 2)
-  qc <- arrow::read_parquet(file.path(odir, grep("lilac_qc", lf, value = TRUE)))
-  expect_named(qc, c("input_id", "status", "score_margin", "next_solution_alleles",
-    "median_base_quality", "hla_y_allele", "discarded_indels", "discarded_indel_max_frags",
-    "discarded_alignment_fragments", "a_low_coverage_bases", "b_low_coverage_bases",
-    "c_low_coverage_bases", "a_types", "b_types", "c_types", "total_fragments",
-    "fitted_fragments", "unmatched_fragments", "uninformative_fragments", "hla_y_fragments",
-    "percent_unique", "percent_shared", "percent_wildcard", "unused_amino_acids",
-    "unused_amino_acid_max_frags", "unused_haplotypes", "unused_haplotype_max_frags",
-    "somatic_variants_matched", "somatic_variants_unmatched"))
-  expect_equal(nrow(qc), 1L)
+  expect_equal(length(lf), 4)
+  qcs <- lapply(grep("lilac_qc", lf, value = TRUE),
+    function(f) names(arrow::read_parquet(file.path(odir, f))))
+  qc_new <- Filter(function(n) "low_coverage_bases" %in% n, qcs)[[1]]
+  qc_old <- Filter(function(n) "a_low_coverage_bases" %in% n, qcs)[[1]]
+  expect_true(all(c("genes", "low_coverage_bases", "gene_types") %in% qc_new))
+  expect_false(any(c("a_low_coverage_bases", "a_types") %in% qc_new))
+  expect_true(all(c("a_low_coverage_bases", "b_low_coverage_bases", "c_low_coverage_bases",
+    "a_types", "b_types", "c_types") %in% qc_old))
+  expect_false(any(c("genes", "low_coverage_bases", "gene_types") %in% qc_old))
+  sms <- lapply(grep("lilac_summary", lf, value = TRUE),
+    function(f) names(arrow::read_parquet(file.path(odir, f))))
+  expect_true(any(vapply(sms, function(n) "genes" %in% n, logical(1))))
+  expect_true(any(vapply(sms, function(n) !("genes" %in% n), logical(1))))
 })
 


### PR DESCRIPTION
## Changes
- `summary` (`lilac.tsv`): ADDITIVE - `Genes` (`latest`); existing cols tagged `v1.7.1` + `latest`.
- `qc`: BREAKING - v3 prepends `Genes`; collapses `A_LowCoverageBases`/`B_LowCoverageBases`/`C_LowCoverageBases` into `LowCoverageBases` and `ATypes`/`BTypes`/`CTypes` into `geneTypes`. Old cols `v1.7.1`, new cols `latest`; shared cols both. `LowCoverageBases`/`geneTypes` are per-gene `gene=count` strings so typed `char`.
- `candidates.coverage`: IGNORED - ragged rows (field count != header count), not in schema, left unparsed.
- No custom parse/tidy methods, default nemo tidy handles both versions.

## DVC
- add: `v1.7.1/sample1.lilac.tsv`, `v1.7.1/sample1.lilac.qc.tsv`
- update: `sample1.lilac.tsv`, `sample1.lilac.qc.tsv` (v3 content)
- `candidates.coverage.tsv` left as-is (unhandled)
- fixture keeps a single sample (`sample1`)

## Tests
- `Lilac` testexamples: 2 -> 4 (summary + qc, each v3 + v1.7.1); version asserted by column content, not sample label
- `make test`: pass
