### PR TITLE
OA v3: Neo update

### DIFF
--- a/R/Neo.R
+++ b/R/Neo.R
@@ -3,23 +3,23 @@
 #' @description
 #' Neo file parsing and manipulation.
 #' @examples
-#' cls <- Neo
-#' indir <- system.file("extdata/oa", package = "tidywigits")
+#' cls <- Neo; tool <- "neo"
+#' indir <- system.file("extdata/oa", tool, package = "tidywigits")
 #' odir <- tempdir()
-#' id <- "neo_run1"
+#' id <- paste0(tool, "_run1")
 #' obj <- cls$new(indir)
 #' obj$run(output_dir = odir, format = "parquet", input_id = id)
-#' (lf <- list.files(odir, pattern = "neo_.*parquet", full.names = FALSE))
+#' (lf <- list.files(odir, pattern = paste0(tool, "_.*parquet"), full.names = FALSE))
 #' @testexamples
-#' expect_equal(length(lf), 2)
-#' preds <- arrow::read_parquet(file.path(odir, grep("neo_predictions", lf, value = TRUE)))
-#' expect_named(preds, c("input_id", "ne_id", "variant_type", "variant_info", "gene_name",
-#'   "aa_up", "aa_novel", "aa_down", "peptide_count", "tpm_source", "rna_frags", "rna_depth",
-#'   "tpm_up", "tpm_down", "tpm_expected", "tpm_raw_effective", "tpm_effective",
-#'   "tpm_cancer_up", "tpm_cancer_down", "tpm_pancancer_up", "tpm_pancancer_down",
-#'   "nmd_min", "nmd_max", "coding_bases_length_min", "coding_bases_length_max",
-#'   "fused_intron_length", "skipped_donors", "skipped_acceptors", "transcripts_up",
-#'   "transcripts_down", "variant_cn", "cn", "subclonal_likelihood"))
+#' expect_equal(length(lf), 4)
+#' pre <- arrow::read_parquet(file.path(odir, grep("neo_predictions", lf, value = TRUE)))
+#' sco <- arrow::read_parquet(file.path(odir, grep("neo_scores", lf, value = TRUE)))
+#' fus <- arrow::read_parquet(file.path(odir, grep("neo_isofusions", lf, value = TRUE)))
+#' can <- arrow::read_parquet(file.path(odir, grep("neo_candidates", lf, value = TRUE)))
+#' expect_true("gene_name" %in% names(pre))
+#' expect_true("score" %in% names(sco))
+#' expect_true("fragment_count" %in% names(fus))
+#' expect_true("variant_type" %in% names(can))
 #' @export
 Neo <- R6::R6Class(
   "Neo",

--- a/R/s3.R
+++ b/R/s3.R
@@ -82,6 +82,8 @@ s3sync <- function(src, dest, pats = NULL) {
     "in"  , "*linx/*.linx.vis_sv_data.tsv"                   ,
     "in"  , "*neo/*.neo.neo_data.tsv"                        ,
     "in"  , "*neo/*.neo.neoepitope.tsv"                      ,
+    "in"  , "*neo/*.neo.peptide_scores.tsv"                  ,
+    "in"  , "*neo/*.isf.neoepitope.tsv"                      ,
     "in"  , "*peach/*.peach.events.tsv"                      ,
     "in"  , "*peach/*.peach.gene.events.tsv"                 ,
     "in"  , "*peach/*.peach.haplotypes.all.tsv"              ,

--- a/inst/config/tools/neo/schema.yaml
+++ b/inst/config/tools/neo/schema.yaml
@@ -344,3 +344,138 @@ tables:
         type: 'float'
         description: 'Subclonal likelihood of variant (for point mutations only)'
         versions: ['latest']
+  scores:
+    description: 'Neoepitope peptide binding scores.'
+    pattern: "\\.neo\\.peptide_scores\\.tsv$"
+    ftype: 'tsv'
+    columns:
+      - raw: 'NeIds'
+        tidy: 'ne_ids'
+        type: 'int'
+        description: 'Unique ID(s) for neoepitope'
+        versions: ['latest']
+      - raw: 'VariantType'
+        tidy: 'variant_type'
+        type: 'char'
+        description: 'MISSENSE, INFRAME, OUT_OF_FRAME_FUSION, INFRAME_FUSION, FRAMESHIFT'
+        versions: ['latest']
+      - raw: 'VariantInfo'
+        tidy: 'variant_info'
+        type: 'char'
+        description: 'Unique identifier for variant'
+        versions: ['latest']
+      - raw: 'Gene'
+        tidy: 'gene'
+        type: 'char'
+        description: 'Gene name or fusion name for fusions'
+        versions: ['latest']
+      - raw: 'Allele'
+        tidy: 'allele'
+        type: 'char'
+        description: 'HLA allele'
+        versions: ['latest']
+      - raw: 'Peptide'
+        tidy: 'peptide'
+        type: 'char'
+        description: 'Novel peptide sequence'
+        versions: ['latest']
+      - raw: 'FlankUp'
+        tidy: 'flank_up'
+        type: 'char'
+        description: 'Upstream flanking AA sequence'
+        versions: ['latest']
+      - raw: 'FlankDown'
+        tidy: 'flank_down'
+        type: 'char'
+        description: 'Downstream flanking AA sequence'
+        versions: ['latest']
+      - raw: 'Score'
+        tidy: 'score'
+        type: 'float'
+        description: 'Peptide binding score'
+        versions: ['latest']
+      - raw: 'Rank'
+        tidy: 'rank'
+        type: 'float'
+        description: 'Peptide binding rank'
+        versions: ['latest']
+      - raw: 'Likelihood'
+        tidy: 'likelihood'
+        type: 'float'
+        description: 'Binding likelihood'
+        versions: ['latest']
+      - raw: 'LikelihoodRank'
+        tidy: 'likelihood_rank'
+        type: 'float'
+        description: 'Binding likelihood rank'
+        versions: ['latest']
+      - raw: 'ExpLikelihood'
+        tidy: 'exp_likelihood'
+        type: 'float'
+        description: 'Expression-weighted binding likelihood'
+        versions: ['latest']
+      - raw: 'ExpLikelihoodRank'
+        tidy: 'exp_likelihood_rank'
+        type: 'float'
+        description: 'Expression-weighted binding likelihood rank'
+        versions: ['latest']
+      - raw: 'EffectiveTpm'
+        tidy: 'tpm_effective'
+        type: 'float'
+        description: 'Combined TPM estimate from direct fragment count and transcript expression'
+        versions: ['latest']
+      - raw: 'RecogSim'
+        tidy: 'recog_sim'
+        type: 'float'
+        description: 'Recognition similarity for the allele'
+        versions: ['latest']
+      - raw: 'OtherAlleleRecogSim'
+        tidy: 'other_allele_recog_sim'
+        type: 'float'
+        description: 'Recognition similarity for the other allele'
+        versions: ['latest']
+      - raw: 'AlleleCN'
+        tidy: 'allele_cn'
+        type: 'float'
+        description: 'HLA allele copy number'
+        versions: ['latest']
+      - raw: 'AlleleDisrupted'
+        tidy: 'allele_disrupted'
+        type: 'char'
+        description: 'Whether the HLA allele is disrupted'
+        versions: ['latest']
+  isofusions:
+    description: 'Isofox-annotated fusion neoepitopes.'
+    pattern: "\\.isf\\.neoepitope\\.tsv$"
+    ftype: 'tsv'
+    columns:
+      - raw: 'NeId'
+        tidy: 'ne_id'
+        type: 'int'
+        description: 'Unique ID for neoepitope'
+        versions: ['latest']
+      - raw: 'VariantType'
+        tidy: 'variant_type'
+        type: 'char'
+        description: 'MISSENSE, INFRAME, OUT_OF_FRAME_FUSION, INFRAME_FUSION, FRAMESHIFT'
+        versions: ['latest']
+      - raw: 'VariantInfo'
+        tidy: 'variant_info'
+        type: 'char'
+        description: 'Unique identifier for variant'
+        versions: ['latest']
+      - raw: 'FragmentCount'
+        tidy: 'fragment_count'
+        type: 'int'
+        description: 'RNA fragments supporting the fusion neoepitope'
+        versions: ['latest']
+      - raw: 'BaseDepthUp'
+        tidy: 'base_depth_up'
+        type: 'int'
+        description: 'RNA base depth at the upstream breakend'
+        versions: ['latest']
+      - raw: 'BaseDepthDown'
+        tidy: 'base_depth_down'
+        type: 'int'
+        description: 'RNA base depth at the downstream breakend'
+        versions: ['latest']

--- a/inst/extdata/oa/neo/.gitignore
+++ b/inst/extdata/oa/neo/.gitignore
@@ -1,2 +1,4 @@
 /sample1.neo.neo_data.tsv
 /sample1.neo.neoepitope.tsv
+/sample1.isf.neoepitope.tsv
+/sample1.neo.peptide_scores.tsv

--- a/inst/extdata/oa/neo/sample1.isf.neoepitope.tsv.dvc
+++ b/inst/extdata/oa/neo/sample1.isf.neoepitope.tsv.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: d9d10791da3693af6e8f9c85426505e7
+  size: 676
+  hash: md5
+  path: sample1.isf.neoepitope.tsv

--- a/inst/extdata/oa/neo/sample1.neo.peptide_scores.tsv.dvc
+++ b/inst/extdata/oa/neo/sample1.neo.peptide_scores.tsv.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 0c3959b1e19361008b8493e9db81a9c7
+  size: 1875
+  hash: md5
+  path: sample1.neo.peptide_scores.tsv

--- a/man/Neo.Rd
+++ b/man/Neo.Rd
@@ -7,13 +7,13 @@
 Neo file parsing and manipulation.
 }
 \examples{
-cls <- Neo
-indir <- system.file("extdata/oa", package = "tidywigits")
+cls <- Neo; tool <- "neo"
+indir <- system.file("extdata/oa", tool, package = "tidywigits")
 odir <- tempdir()
-id <- "neo_run1"
+id <- paste0(tool, "_run1")
 obj <- cls$new(indir)
 obj$run(output_dir = odir, format = "parquet", input_id = id)
-(lf <- list.files(odir, pattern = "neo_.*parquet", full.names = FALSE))
+(lf <- list.files(odir, pattern = paste0(tool, "_.*parquet"), full.names = FALSE))
 }
 \section{Super class}{
 \code{\link[nemo:Tool]{nemo::Tool}} -> \code{Neo}

--- a/tests/testthat/test-roxytest-testexamples-Neo.R
+++ b/tests/testthat/test-roxytest-testexamples-Neo.R
@@ -4,21 +4,21 @@
 
 test_that("Function Neo() @ L24", {
   
-  cls <- Neo
-  indir <- system.file("extdata/oa", package = "tidywigits")
+  cls <- Neo; tool <- "neo"
+  indir <- system.file("extdata/oa", tool, package = "tidywigits")
   odir <- tempdir()
-  id <- "neo_run1"
+  id <- paste0(tool, "_run1")
   obj <- cls$new(indir)
   obj$run(output_dir = odir, format = "parquet", input_id = id)
-  (lf <- list.files(odir, pattern = "neo_.*parquet", full.names = FALSE))
-  expect_equal(length(lf), 2)
-  preds <- arrow::read_parquet(file.path(odir, grep("neo_predictions", lf, value = TRUE)))
-  expect_named(preds, c("input_id", "ne_id", "variant_type", "variant_info", "gene_name",
-    "aa_up", "aa_novel", "aa_down", "peptide_count", "tpm_source", "rna_frags", "rna_depth",
-    "tpm_up", "tpm_down", "tpm_expected", "tpm_raw_effective", "tpm_effective",
-    "tpm_cancer_up", "tpm_cancer_down", "tpm_pancancer_up", "tpm_pancancer_down",
-    "nmd_min", "nmd_max", "coding_bases_length_min", "coding_bases_length_max",
-    "fused_intron_length", "skipped_donors", "skipped_acceptors", "transcripts_up",
-    "transcripts_down", "variant_cn", "cn", "subclonal_likelihood"))
+  (lf <- list.files(odir, pattern = paste0(tool, "_.*parquet"), full.names = FALSE))
+  expect_equal(length(lf), 4)
+  pre <- arrow::read_parquet(file.path(odir, grep("neo_predictions", lf, value = TRUE)))
+  sco <- arrow::read_parquet(file.path(odir, grep("neo_scores", lf, value = TRUE)))
+  fus <- arrow::read_parquet(file.path(odir, grep("neo_isofusions", lf, value = TRUE)))
+  can <- arrow::read_parquet(file.path(odir, grep("neo_candidates", lf, value = TRUE)))
+  expect_true("gene_name" %in% names(pre))
+  expect_true("score" %in% names(sco))
+  expect_true("fragment_count" %in% names(fus))
+  expect_true("variant_type" %in% names(can))
 })
 


### PR DESCRIPTION
## Changes
- `scores`: ADDITIVE - new table for `.neo.peptide_scores.tsv` (HLA peptide binding scores, 19 cols). Default tidy, no custom method.
- `isofusions`: ADDITIVE - new table for `.isf.neoepitope.tsv` (isofox-annotated fusion neoepitope RNA support, 6 cols). Default tidy.
- `candidates`, `predictions`: IDENTICAL - v3 `neo_data` header unchanged. Old flat fixture kept, no schema change.
- `s3.R`: +2 include patterns (`*.neo.peptide_scores.tsv`, `*.isf.neoepitope.tsv`).

## DVC
- add: `sample1.neo.peptide_scores.tsv`, `sample1.isf.neoepitope.tsv`
- no moves/removes (identical tables untouched, nothing demoted)

## Tests
- `Neo` testexamples: 2 -> 4 outputs (adds `neo_scores`, `neo_isofusions`)
- `make test`: pass
